### PR TITLE
add setup.sh script for easy CLI setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ A powerful command-line interface for interacting with the Pipe distributed stor
 
 curl -sL https://raw.githubusercontent.com/pipenetwork/pipe/main/setup.sh | bash
 
-
 ```
 
 ## Manually Installation

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ A powerful command-line interface for interacting with the Pipe distributed stor
 
 ## Auto Installation
 ```bash
-wget -O auto.sh https://raw.githubusercontent.com/whoopsme1337/pipe-cli/refs/heads/main/setup.sh
-chmod +x auto.sh
-./auto.sh
+
+curl -sL https://raw.githubusercontent.com/whoopsme1337/pipe-cli/refs/heads/main/setup.sh | bash
+
 ```
 
 ## Manually Installation

--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ A powerful command-line interface for interacting with the Pipe distributed stor
 - **Multiple Account Support**: Manage multiple accounts with custom config files
 - **Local Key Management**: Generate and manage encryption keys locally with built-in keyring
 
+## Auto Installation
+```bash
+wget -O auto.sh https://raw.githubusercontent.com/whoopsme1337/pipe-cli/refs/heads/main/setup.sh
+chmod +x auto.sh
+./auto.sh
+```
+
+## Manually Installation
+
 ## Prerequisites
 To build make sure you have [Rust](https://www.rust-lang.org/tools/install) and required system packages installed :
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ A powerful command-line interface for interacting with the Pipe distributed stor
 ## Auto Installation
 ```bash
 
-curl -sL https://raw.githubusercontent.com/pipenetwork/pipe/refs/heads/main/setup.sh | bash
+curl -sL https://raw.githubusercontent.com/pipenetwork/pipe/main/setup.sh | bash
+
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A powerful command-line interface for interacting with the Pipe distributed stor
 ## Auto Installation
 ```bash
 
-curl -sL https://raw.githubusercontent.com/whoopsme1337/pipe-cli/refs/heads/main/setup.sh | bash
+curl -sL https://raw.githubusercontent.com/pipenetwork/pipe-cli/refs/heads/main/setup.sh | bash
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A powerful command-line interface for interacting with the Pipe distributed stor
 ## Auto Installation
 ```bash
 
-curl -sL https://raw.githubusercontent.com/pipenetwork/pipe-cli/refs/heads/main/setup.sh | bash
+curl -sL https://raw.githubusercontent.com/pipenetwork/pipe/refs/heads/main/setup.sh | bash
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A powerful command-line interface for interacting with the Pipe distributed stor
 ## Auto Installation
 ```bash
 
-curl -sL https://raw.githubusercontent.com/pipenetwork/pipe/main/setup.sh | bash
+bash <(curl -sSL https://raw.githubusercontent.com/pipenetwork/pipe/main/setup.sh)
 
 ```
 

--- a/setup.sh
+++ b/setup.sh
@@ -16,9 +16,6 @@ cd pipe
 echo "🔧 Building pipe CLI..."
 cargo install --path .
 
-echo "📁 Moving pipe binary to /usr/local/bin..."
-sudo cp target/release/pipe /usr/local/bin/pipe
-
 echo "✅ Done! Test with:"
 echo ""
 echo "    pipe --help"

--- a/setup.sh
+++ b/setup.sh
@@ -2,12 +2,18 @@
 
 set -e
 
-echo "🚀 Installing rustup..."
-curl https://sh.rustup.rs -sSf | sh -s -- -y
-source $HOME/.cargo/env
-
-echo "🎯 install Dependensi..."
+echo "🎯 Installing system dependencies..."
 sudo apt update && sudo apt install -y build-essential pkg-config libssl-dev git curl
+
+# Check if Rust is already installed
+if command -v rustc &> /dev/null
+then
+    echo "✅ Rust is already installed. Skipping rustup installation."
+else
+    echo "🚀 Installing rustup..."
+    curl https://sh.rustup.rs -sSf | sh -s -- -y
+    source $HOME/.cargo/env
+fi
 
 echo "📦 Cloning Pipe repo..."
 git clone https://github.com/PipeNetwork/pipe.git

--- a/setup.sh
+++ b/setup.sh
@@ -2,26 +2,65 @@
 
 set -e
 
-echo "🎯 Installing system dependencies..."
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+CYAN='\033[0;36m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${CYAN}🎯 Installing system dependencies...${NC}"
 sudo apt update && sudo apt install -y build-essential pkg-config libssl-dev git curl
 
-# Check if Rust is already installed
-if command -v rustc &> /dev/null
-then
-    echo "✅ Rust is already installed. Skipping rustup installation."
+MIN_RUST_VERSION="1.70.0"
+should_install_rust=false
+
+if command -v rustc &> /dev/null && command -v cargo &> /dev/null; then
+    INSTALLED_RUST_VERSION=$(rustc --version | awk '{print $2}')
+    echo -e "${CYAN}🔍 Detected rustc ${INSTALLED_RUST_VERSION}${NC}"
+
+    if [ "$(printf '%s\n' "$INSTALLED_RUST_VERSION" "$MIN_RUST_VERSION" | sort -V | head -n1)" != "$MIN_RUST_VERSION" ]; then
+        echo -e "${YELLOW}⚠️ Rust version is too old (< ${MIN_RUST_VERSION}). Updating via rustup...${NC}"
+        should_install_rust=true
+    else
+        echo -e "${GREEN}✅ Rust version is sufficient. Skipping installation.${NC}"
+    fi
 else
-    echo "🚀 Installing rustup..."
+    echo -e "${YELLOW}🚫 Rust or Cargo not found.${NC}"
+    should_install_rust=true
+fi
+
+if [ "$should_install_rust" = true ]; then
+    echo -e "${CYAN}🚀 Installing rustup (Rust & Cargo)...${NC}"
     curl https://sh.rustup.rs -sSf | sh -s -- -y
     source $HOME/.cargo/env
 fi
 
-echo "📦 Cloning Pipe repo..."
-git clone https://github.com/PipeNetwork/pipe.git
+# Handle --force flag
+if [[ "$1" == "--force" ]]; then
+    echo -e "${YELLOW}⚠️ --force enabled. Removing existing 'pipe' folder...${NC}"
+    rm -rf pipe
+fi
+
+if [ -d "pipe" ]; then
+    echo -e "${YELLOW}📁 'pipe' folder already exists. Skipping clone.${NC}"
+else
+    echo -e "${CYAN}📦 Cloning Pipe repo...${NC}"
+    git clone https://github.com/PipeNetwork/pipe.git
+fi
 cd pipe
 
-echo "🔧 Building pipe CLI..."
-cargo install --path .
+echo -e "${CYAN}🔧 Building Pipe CLI...${NC}"
+if cargo install --path .; then
+    echo -e "${GREEN}✅ Build successful!${NC}"
+else
+    echo -e "${RED}❌ Build failed. Please check the error log.${NC}"
+    exit 1
+fi
 
-echo "✅ Done! Test with:"
-echo ""
-echo "    pipe --help"
+if command -v pipe &> /dev/null; then
+    echo -e "\n${GREEN}🚀 All set! You can now run:${NC}"
+    echo -e "    ${CYAN}pipe --help${NC}\n"
+else
+    echo -e "\n${RED}⚠️ Setup complete, but 'pipe' command not found in PATH.${NC}"
+    echo -e "${YELLOW}You might need to restart your terminal or add ~/.cargo/bin to PATH.${NC}\n"
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+echo "🚀 Installing rustup..."
+curl https://sh.rustup.rs -sSf | sh -s -- -y
+source $HOME/.cargo/env
+
+echo "🎯 install Dependensi..."
+sudo apt update && sudo apt install -y build-essential pkg-config libssl-dev git curl
+
+echo "📦 Cloning Pipe repo..."
+git clone https://github.com/PipeNetwork/pipe.git
+cd pipe
+
+echo "🔧 Building pipe CLI..."
+cargo install --path .
+
+echo "📁 Moving pipe binary to /usr/local/bin..."
+sudo cp target/release/pipe /usr/local/bin/pipe
+
+echo "✅ Done! Test with:"
+echo ""
+echo "    pipe --help"


### PR DESCRIPTION
This PR adds a simple and user-friendly setup.sh script to help new users:

> Install required system dependencies
> Install Rust only if missing
> Clone the repo and build the CLI in one go

The goal is to improve the onboarding experience, especially for non-technical users who may struggle with manual setup. This script is optional, safe to run, and has no effect on core logic.

Tested on Ubuntu/Debian/WSL. Can be extended later for other distros.