### PR TITLE
Add pipe update command for self-updating

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ pipe referral apply CODE-1234 # Apply someone's referral code
 # Sync directories (NEW!)
 pipe sync ./local/folder remote/folder  # Upload sync
 pipe sync remote/folder ./local/folder  # Download sync (limited)
+
+# update pipe-cli
+pipe update
 ```
 
 ### Encryption (NEW!)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6731,7 +6731,6 @@ pub async fn run_cli() -> Result<()> {
                 }
             }
         }
-        /// update command
         Commands::Update => {
             update::update_command().await?;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6731,6 +6731,7 @@ pub async fn run_cli() -> Result<()> {
                 }
             }
         }
+        // update command
         Commands::Update => {
             update::update_command().await?;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ use tokio::sync::Mutex as TokioMutex;
 use tokio::sync::Semaphore;
 use walkdir::WalkDir;
 
+mod update;
 mod encryption;
 mod keyring;
 mod quantum;
@@ -562,6 +563,8 @@ pub enum Commands {
         #[arg(long, default_value = "5")]
         parallel: usize,
     },
+    /// Update Pipe CLI to the latest version
+    Update,
 }
 
 #[derive(Subcommand, Debug)]
@@ -576,6 +579,8 @@ pub enum ReferralCommands {
         code: String,
     },
 }
+
+
 
 #[derive(Serialize, Deserialize)]
 pub struct CreateUserRequest {
@@ -6726,7 +6731,10 @@ pub async fn run_cli() -> Result<()> {
                 }
             }
         }
+        /// update command
+        Commands::Update => {
+            update::update_command().await?;
+        }
     }
-
     Ok(())
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,0 +1,42 @@
+use anyhow::{Result, anyhow};
+use std::process::Command;
+use std::fs;
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub async fn update_command() -> Result<()> {
+    println!("\n Updating Pipe-CLI...");
+
+    let timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+    let update_dir = format!("pipe-update-{}", timestamp);
+
+    if Path::new(&update_dir).exists() {
+        fs::remove_dir_all(&update_dir)?;
+    }
+
+    // Clone repo
+    let status = Command::new("git")
+        .args(&["clone", "https://github.com/PipeNetwork/pipe.git", &update_dir])
+        .status()?;
+    if !status.success() {
+        let _ = fs::remove_dir_all(&update_dir);
+        return Err(anyhow!("Failed to clone repository"));
+    }
+
+    // Re-build
+    let status = Command::new("cargo")
+        .args(&["install", "--path", &update_dir])
+        .status()?;
+    if !status.success() {
+        let _ = fs::remove_dir_all(&update_dir);
+        return Err(anyhow!("Failed to install new version"));
+    }
+
+    // Remove cloned repo
+    if Path::new(&update_dir).exists() {
+        fs::remove_dir_all(&update_dir)?;
+    }
+
+    println!("\n ✅ Pipe CLI updated successfully!");
+    Ok(())
+}


### PR DESCRIPTION
adds a new `pipe update` subcommand to pipe-cli

Key changes :
- `update.rs` to handle update process
- Integrated the update command into the CLI
- This feature makes it easier for users to keep their Pipe CLI up to date with the latest releases